### PR TITLE
Fix Redis TTL refresh bug

### DIFF
--- a/src/main/java/com/hmdp/utils/RefreshTokenInterceptor.java
+++ b/src/main/java/com/hmdp/utils/RefreshTokenInterceptor.java
@@ -40,7 +40,8 @@ public class RefreshTokenInterceptor implements HandlerInterceptor {
         UserDTO userDTO = BeanUtil.fillBeanWithMap(userMap, new UserDTO(), false);
         UserHolder.saveUser(BeanUtil.copyProperties(userMap, UserDTO.class));
         // 4、刷新token有效期
-        stringRedisTemplate.expire(token, LOGIN_USER_TTL, TimeUnit.MINUTES);
+        // 刷新 token 在 Redis 中的有效期
+        stringRedisTemplate.expire(tokenKey, LOGIN_USER_TTL, TimeUnit.MINUTES);
         return true;
     }
 


### PR DESCRIPTION
## Summary
- fix Redis token key TTL extension in `RefreshTokenInterceptor`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a347a7fc8832e988d44eeb656c955