### PR TITLE
Fix cache expiration bug and enhance tests

### DIFF
--- a/src/main/java/com/hmdp/service/impl/ShopServiceImpl.java
+++ b/src/main/java/com/hmdp/service/impl/ShopServiceImpl.java
@@ -94,9 +94,9 @@ public class ShopServiceImpl extends ServiceImpl<ShopMapper, Shop> implements IS
         //6.缓存重建
         //6.1 获取互斥锁
         String lockKey = LOCK_SHOP_KEY + id;
-        boolean islock = trylock(lockKey);
+        boolean isLock = tryLock(lockKey);
         //6.2 判断是否获取锁成功
-        if(islock){
+        if(isLock){
             //6.3 成功，开启独立线程，实现缓存重建
             CACHE_REBUILD_EXECUTOR.submit(() -> {
                 this.saveShop2Redis(id,30L);
@@ -123,9 +123,9 @@ public class ShopServiceImpl extends ServiceImpl<ShopMapper, Shop> implements IS
         //3.实现缓存重建
         //3.1 获取互斥锁
         String lockKey = "lock:shop:" + id;
-        boolean islock = trylock(lockKey);
+        boolean isLock = tryLock(lockKey);
         //3.2 判断是否成功
-        if(!islock){
+        if(!isLock){
             //3.3 失败，则休眠并重试
             Thread.sleep(50);
             return queryWithMutex(id);
@@ -181,7 +181,7 @@ public class ShopServiceImpl extends ServiceImpl<ShopMapper, Shop> implements IS
         return shop;
     }
 
-    private boolean trylock(String key){
+    private boolean tryLock(String key){
         Boolean flag = stringRedisTemplate.opsForValue().setIfAbsent(key, "1", 10, TimeUnit.SECONDS);
         return BooleanUtil.isTrue(flag);
     }

--- a/src/main/java/com/hmdp/utils/CacheClient.java
+++ b/src/main/java/com/hmdp/utils/CacheClient.java
@@ -39,7 +39,7 @@ public class CacheClient {
         RedisData redisData = new RedisData();
         redisData.setData(value);
         redisData.setExpireTime(LocalDateTime.now().plusSeconds(unit.toSeconds(time)));
-        stringRedisTemplate.opsForValue().set(key, JSONUtil.toJsonStr(value));
+        stringRedisTemplate.opsForValue().set(key, JSONUtil.toJsonStr(redisData));
     }
 
     public <R,ID> R queryWithPassThrough(

--- a/src/main/java/com/hmdp/utils/RefreshTokenInterceptor.java
+++ b/src/main/java/com/hmdp/utils/RefreshTokenInterceptor.java
@@ -40,7 +40,7 @@ public class RefreshTokenInterceptor implements HandlerInterceptor {
         UserDTO userDTO = BeanUtil.fillBeanWithMap(userMap, new UserDTO(), false);
         UserHolder.saveUser(BeanUtil.copyProperties(userMap, UserDTO.class));
         // 4、刷新token有效期
-        stringRedisTemplate.expire(token, LOGIN_USER_TTL, TimeUnit.MINUTES);
+        stringRedisTemplate.expire(tokenKey, LOGIN_USER_TTL, TimeUnit.MINUTES);
         return true;
     }
 

--- a/src/main/java/com/hmdp/utils/RegexUtils.java
+++ b/src/main/java/com/hmdp/utils/RegexUtils.java
@@ -9,7 +9,7 @@ public class RegexUtils {
     /**
      * 是否是无效手机格式
      * @param phone 要校验的手机号
-     * @return true:符合，false：不符合
+     * @return true:不符合，false：符合
      */
     public static boolean isPhoneInvalid(String phone){
         return mismatch(phone, RegexPatterns.PHONE_REGEX);
@@ -17,7 +17,7 @@ public class RegexUtils {
     /**
      * 是否是无效邮箱格式
      * @param email 要校验的邮箱
-     * @return true:符合，false：不符合
+     * @return true:不符合，false：符合
      */
     public static boolean isEmailInvalid(String email){
         return mismatch(email, RegexPatterns.EMAIL_REGEX);
@@ -26,7 +26,7 @@ public class RegexUtils {
     /**
      * 是否是无效验证码格式
      * @param code 要校验的验证码
-     * @return true:符合，false：不符合
+     * @return true:不符合，false：符合
      */
     public static boolean isCodeInvalid(String code){
         return mismatch(code, RegexPatterns.VERIFY_CODE_REGEX);

--- a/src/test/java/com/hmdp/HmDianPingApplicationTests.java
+++ b/src/test/java/com/hmdp/HmDianPingApplicationTests.java
@@ -3,6 +3,7 @@ package com.hmdp;
 import com.hmdp.entity.Shop;
 import com.hmdp.mapper.ShopMapper;
 import com.hmdp.service.impl.ShopServiceImpl;
+import com.hmdp.utils.PasswordEncoder;
 import com.hmdp.utils.RedisConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -73,5 +74,14 @@ class HmDianPingApplicationTests {
         assertNotNull(finalShop, "重建后查询不应为空");
 
         System.out.println("测试成功！完整地验证了逻辑过期的全过程。");
-}
     }
+
+    @Test
+    void passwordEncoderWorks() {
+        String raw = "secret";
+        String encoded = PasswordEncoder.encode(raw);
+        assertNotNull(encoded, "编码结果不应为空");
+        org.junit.jupiter.api.Assertions.assertTrue(PasswordEncoder.matches(encoded, raw));
+        org.junit.jupiter.api.Assertions.assertFalse(PasswordEncoder.matches(encoded, "other"));
+    }
+}


### PR DESCRIPTION
## Summary
- correct caching logic in `CacheClient`
- fix token expiration refresh
- clarify RegexUtils return docs
- clean up lock naming in ShopServiceImpl
- add PasswordEncoder unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a347a8f68832ea7d72cdf9727567e